### PR TITLE
19 improve handling of the designated note

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,12 @@ export default class CustomSortPlugin extends Plugin {
 				// - files with designated name (sortspec.md by default)
 				// - files with the same name as parent folders (aka folder notes): References/References.md
 				// - the file explicitly indicated in documentation, by default Inbox/Inbox.md
-				if (aFile.name === SORTSPEC_FILE_NAME || aFile.basename === parent.name || aFile.path === this.settings.additionalSortspecFile) {
+				if (aFile.name === SORTSPEC_FILE_NAME ||
+					aFile.basename === parent.name ||
+					aFile.basename === this.settings.additionalSortspecFile ||
+					aFile.path === this.settings.additionalSortspecFile ||
+					aFile.path === this.settings.additionalSortspecFile + '.md'
+				) {
 					const sortingSpecTxt: string = mCache.getCache(aFile.path)?.frontmatter?.[SORTINGSPEC_YAML_KEY]
 					if (sortingSpecTxt) {
 						anySortingSpecFound = true
@@ -328,9 +333,9 @@ class CustomSortSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('Path to the designated note containing sorting specification')
-			.setDesc('The YAML front matter of this note will be scanned for sorting specification, in addition to the sortspec.md notes and folder notes. Remember to add the `.md` explicitly here.')
+			.setDesc('The YAML front matter of this note will be scanned for sorting specification, in addition to the `sortspec` notes and folder notes. The `.md` filename suffix is optional.')
 			.addText(text => text
-				.setPlaceholder('e.g. Inbox/Inbox.md')
+				.setPlaceholder('e.g. Inbox/sort')
 				.setValue(this.plugin.settings.additionalSortspecFile)
 				.onChange(async (value) => {
 					this.plugin.settings.additionalSortspecFile = value.trim() ? normalizePath(value) : '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,9 +84,9 @@ export default class CustomSortPlugin extends Plugin {
 				// - the file explicitly indicated in documentation, by default Inbox/Inbox.md
 				if (aFile.name === SORTSPEC_FILE_NAME ||
 					aFile.basename === parent.name ||
-					aFile.basename === this.settings.additionalSortspecFile ||
-					aFile.path === this.settings.additionalSortspecFile ||
-					aFile.path === this.settings.additionalSortspecFile + '.md'
+					aFile.basename === this.settings.additionalSortspecFile ||  // (A) 'Inbox/sort' === setting 'Inbox/sort'
+					aFile.path === this.settings.additionalSortspecFile ||      // (B) 'Inbox/sort.md' === setting 'Inbox/sort.md'
+					aFile.path === this.settings.additionalSortspecFile + '.md' // (C) 'Inbox/sort.md.md' === setting 'Inbox/sort.md'
 				) {
 					const sortingSpecTxt: string = mCache.getCache(aFile.path)?.frontmatter?.[SORTINGSPEC_YAML_KEY]
 					if (sortingSpecTxt) {


### PR DESCRIPTION
In result of this PR, the following are handled in a more user friendly manner:
- `sort` designated note path entered in plugin settings causes `sort.md` file to be scanned
- `sort.md` designated note path entered in plugin settings causes `sort.md` and `sort.md.md` files to be scanned