### PR TITLE
#58 - Some target-folder: get ignored when sorting specs are read fro…

### DIFF
--- a/src/custom-sort/sorting-spec-processor.spec.ts
+++ b/src/custom-sort/sorting-spec-processor.spec.ts
@@ -930,7 +930,7 @@ describe('SortingSpecProcessor target-folder by name and regex', () => {
 	it('should correctly handle the by-name only target-folder', () => {
 		const inputTxtArr: Array<string> = txtInputTargetFolderByName.split('\n')
 		const result = processor.parseSortSpecFromText(inputTxtArr, 'mock-folder', 'custom-name-note.md')
-		expect(result?.sortSpecByPath).toEqual({})
+		expect(result?.sortSpecByPath).toBeUndefined()
 		expect(result?.sortSpecByName).toEqual(expectedSortSpecsTargetFolderByName)
 		expect(result?.sortSpecByWildcard).not.toBeNull()
 	})

--- a/src/main.ts
+++ b/src/main.ts
@@ -334,8 +334,8 @@ export default class CustomSortPlugin extends Plugin {
 
 						// if custom sort is not specified, use the UI-selected
 						const folder: TFolder = this.file
-						let sortSpec: CustomSortSpec | null | undefined = plugin.sortSpecCache?.sortSpecByPath[folder.path]
-						sortSpec = sortSpec ?? plugin.sortSpecCache?.sortSpecByName[folder.name]
+						let sortSpec: CustomSortSpec | null | undefined = plugin.sortSpecCache?.sortSpecByPath?.[folder.path]
+						sortSpec = sortSpec ?? plugin.sortSpecCache?.sortSpecByName?.[folder.name]
 						if (sortSpec) {
 							if (sortSpec.defaultOrder === CustomSortOrder.standardObsidian) {
 								sortSpec = null // A folder is explicitly excluded from custom sorting plugin


### PR DESCRIPTION
Fixed a bug introduced in [1.6.0](https://github.com/SebastianMC/obsidian-custom-sort/releases/tag/1.6.0) when the `target-folder:` match-by-name (non-regexp) feature was added.