### PR TITLE
60 simplified integration with obsidian icon folder

### DIFF
--- a/src/custom-sort/custom-sort-types.ts
+++ b/src/custom-sort/custom-sort-types.ts
@@ -8,7 +8,8 @@ export enum CustomSortGroupType {
 	ExactSuffix,
 	ExactHeadAndTail, // Like W...n or Un...ed, which is shorter variant of typing the entire title
 	HasMetadataField,  // Notes (or folder's notes) containing a specific metadata field
-	StarredOnly
+	StarredOnly,
+	IconFolderPlugin
 }
 
 export enum CustomSortOrder {
@@ -59,6 +60,7 @@ export interface CustomSortGroup {
 	matchFilenameWithExt?: boolean
 	foldersOnly?: boolean
 	withMetadataFieldName?: string // for 'with-metadata:' grouping
+	folderIconName?: string // for integration with obsidian-folder-icon community plugin
 	priority?: number
 	combineWithIdx?: number
 }

--- a/src/custom-sort/custom-sort-types.ts
+++ b/src/custom-sort/custom-sort-types.ts
@@ -9,7 +9,7 @@ export enum CustomSortGroupType {
 	ExactHeadAndTail, // Like W...n or Un...ed, which is shorter variant of typing the entire title
 	HasMetadataField,  // Notes (or folder's notes) containing a specific metadata field
 	StarredOnly,
-	IconFolderPlugin
+	HasIcon
 }
 
 export enum CustomSortOrder {
@@ -60,7 +60,7 @@ export interface CustomSortGroup {
 	matchFilenameWithExt?: boolean
 	foldersOnly?: boolean
 	withMetadataFieldName?: string // for 'with-metadata:' grouping
-	folderIconName?: string // for integration with obsidian-folder-icon community plugin
+	iconName?: string // for integration with obsidian-folder-icon community plugin
 	priority?: number
 	combineWithIdx?: number
 }

--- a/src/custom-sort/custom-sort.spec.ts
+++ b/src/custom-sort/custom-sort.spec.ts
@@ -1071,14 +1071,14 @@ describe('determineSortingGroup', () => {
 			expect(starredPluginInstance.findStarredFile).toHaveBeenCalledTimes(2)
 		})
 	})
-	describe('CustomSortGroupType.IconFolderPlugin', () => {
+	describe('CustomSortGroupType.HasIcon', () => {
 		it('should not match file w/o icon', () => {
 			// given
 			const file: TFile = mockTFile('References', 'md', 111, MOCK_TIMESTAMP + 222, MOCK_TIMESTAMP + 333);
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin
+					type: CustomSortGroupType.HasIcon
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1110,8 +1110,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'IncorrectIconName'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'IncorrectIconName'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1146,7 +1146,7 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin
+					type: CustomSortGroupType.HasIcon
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1181,8 +1181,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'CorrectIconName'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'CorrectIconName'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1217,7 +1217,7 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin
+					type: CustomSortGroupType.HasIcon
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1257,7 +1257,7 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin
+					type: CustomSortGroupType.HasIcon
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1300,7 +1300,7 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin
+					type: CustomSortGroupType.HasIcon
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1346,8 +1346,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'ConfiguredIcon-by-string'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'ConfiguredIcon-by-string'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1390,8 +1390,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'ConfiguredIcon'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'ConfiguredIcon'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1437,8 +1437,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'ConfiguredIcon-by-string'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'ConfiguredIcon-by-string'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
@@ -1481,8 +1481,8 @@ describe('determineSortingGroup', () => {
 			const sortSpec: CustomSortSpec = {
 				targetFoldersPaths: ['/'],
 				groups: [{
-					type: CustomSortGroupType.IconFolderPlugin,
-					folderIconName: 'ConfiguredIcon'
+					type: CustomSortGroupType.HasIcon,
+					iconName: 'ConfiguredIcon'
 				}]
 			}
 			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {

--- a/src/custom-sort/custom-sort.spec.ts
+++ b/src/custom-sort/custom-sort.spec.ts
@@ -12,6 +12,10 @@ import {
 import {CustomSortGroupType, CustomSortOrder, CustomSortSpec, RegExpSpec} from './custom-sort-types';
 import {CompoundDashNumberNormalizerFn, CompoundDotRomanNumberNormalizerFn} from "./sorting-spec-processor";
 import {findStarredFile_pathParam, Starred_PluginInstance} from "../utils/StarredPluginSignature";
+import {
+	ObsidianIconFolder_PluginInstance,
+	ObsidianIconFolderPlugin_Data
+} from "../utils/ObsidianIconFolderPluginSignature";
 
 const mockTFile = (basename: string, ext: string, size?: number, ctime?: number, mtime?: number): TFile => {
 	return {
@@ -1065,6 +1069,458 @@ describe('determineSortingGroup', () => {
 			});
 				// assume optimized checking of starred items -> first match ends the check
 			expect(starredPluginInstance.findStarredFile).toHaveBeenCalledTimes(2)
+		})
+	})
+	describe('CustomSortGroupType.IconFolderPlugin', () => {
+		it('should not match file w/o icon', () => {
+			// given
+			const file: TFile = mockTFile('References', 'md', 111, MOCK_TIMESTAMP + 222, MOCK_TIMESTAMP + 333);
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {settings: {}}  // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(file, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 1,  // The lastIdx+1, group not determined
+				isFolder: false,
+				sortString: "References.md",
+				ctimeNewest: MOCK_TIMESTAMP + 222,
+				ctimeOldest: MOCK_TIMESTAMP + 222,
+				mtime: MOCK_TIMESTAMP + 333,
+				path: 'Some parent folder/References.md'
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should not match file with icon of different name', () => {
+			// given
+			const file: TFile = mockTFile('References', 'md', 111, MOCK_TIMESTAMP + 222, MOCK_TIMESTAMP + 333);
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'IncorrectIconName'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'Some parent folder/References.md': 'CorrectIconName'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(file, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 1,  // The lastIdx+1, group not determined
+				isFolder: false,
+				sortString: "References.md",
+				ctimeNewest: MOCK_TIMESTAMP + 222,
+				ctimeOldest: MOCK_TIMESTAMP + 222,
+				mtime: MOCK_TIMESTAMP + 333,
+				path: 'Some parent folder/References.md'
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match file with any icon', () => {
+			// given
+			const file: TFile = mockTFile('References', 'md', 111, MOCK_TIMESTAMP + 222, MOCK_TIMESTAMP + 333);
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'Some parent folder/References.md': 'Irrelevant icon name, only presence matters'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(file, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: false,
+				sortString: "References.md",
+				ctimeNewest: MOCK_TIMESTAMP + 222,
+				ctimeOldest: MOCK_TIMESTAMP + 222,
+				mtime: MOCK_TIMESTAMP + 333,
+				path: 'Some parent folder/References.md'
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match file with icon of expected name', () => {
+			// given
+			const file: TFile = mockTFile('References', 'md', 111, MOCK_TIMESTAMP + 222, MOCK_TIMESTAMP + 333);
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'CorrectIconName'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'Some parent folder/References.md': 'CorrectIconName'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(file, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: false,
+				sortString: "References.md",
+				ctimeNewest: MOCK_TIMESTAMP + 222,
+				ctimeOldest: MOCK_TIMESTAMP + 222,
+				mtime: MOCK_TIMESTAMP + 333,
+				path: 'Some parent folder/References.md'
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should not match folder w/o icon', () => {
+			// given
+			const folder: TFolder = mockTFolder('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {settings: {}}  // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 1,  // The lastIdx+1, group not determined
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: [],
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match folder with any icon (icon specified by string alone)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': 'Irrelevant icon name, only presence matters'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match folder with any icon (icon specified together with inheritance)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': {
+							iconName: 'ConfiguredIcon',
+							inheritanceIcon: 'ConfiguredInheritanceIcon'
+						}
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match folder with specified icon (icon specified by string alone)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'ConfiguredIcon-by-string'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': 'ConfiguredIcon-by-string'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should match folder with specified icon (icon specified together with inheritance)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'ConfiguredIcon'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': {
+							iconName: 'ConfiguredIcon',
+							inheritanceIcon: 'ConfiguredInheritanceIcon'
+						}
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 0,
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should not match folder with different icon (icon specified by string alone)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'ConfiguredIcon-by-string'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': 'AnotherConfiguredIcon-by-string'
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 1, // lastIdx+1 - no match
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
+		})
+		it('should not match folder with different icon (icon specified together with inheritance)', () => {
+			// given
+			const folder: TFolder = mockTFolderWithChildren('TestEmptyFolder');
+			const sortSpec: CustomSortSpec = {
+				targetFoldersPaths: ['/'],
+				groups: [{
+					type: CustomSortGroupType.IconFolderPlugin,
+					folderIconName: 'ConfiguredIcon'
+				}]
+			}
+			const obsidianIconFolderPluginInstance: Partial<ObsidianIconFolder_PluginInstance> = {
+				getData: jest.fn( function(): ObsidianIconFolderPlugin_Data {
+					return {
+						settings: {}, // The obsidian-folder-icon plugin keeps the settings there indeed ;-)
+						'TestEmptyFolder': {
+							iconName: 'OtherConfiguredIcon',
+							inheritanceIcon: 'ConfiguredInheritanceIcon'
+						}
+					}
+				})
+			}
+
+			// when
+			const result = determineSortingGroup(folder, sortSpec, {
+				iconFolderPluginInstance: obsidianIconFolderPluginInstance as ObsidianIconFolder_PluginInstance
+			})
+
+			// then
+			expect(result).toEqual({
+				groupIdx: 1,  // lastIdx+1 - no match
+				isFolder: true,
+				sortString: "TestEmptyFolder",
+				ctimeNewest: 0,
+				ctimeOldest: 0,
+				mtime: 0,
+				path: 'TestEmptyFolder',
+				folder: {
+					children: expect.any(Array),
+					isRoot: expect.any(Function),
+					name: "TestEmptyFolder",
+					parent: {},
+					path: "TestEmptyFolder",
+					vault: {}
+				}
+			});
+			expect(obsidianIconFolderPluginInstance.getData).toHaveBeenCalledTimes(1)
 		})
 	})
 	describe('when sort by metadata is involved', () => {

--- a/src/custom-sort/custom-sort.ts
+++ b/src/custom-sort/custom-sort.ts
@@ -271,12 +271,12 @@ export const determineSortingGroup = function (entry: TFile | TFolder, spec: Cus
 					}
 				}
 				break
-			case CustomSortGroupType.IconFolderPlugin:
+			case CustomSortGroupType.HasIcon:
 				if(ctx?.iconFolderPluginInstance) {
 					let iconName: string | undefined = determineIconOf(entry, ctx.iconFolderPluginInstance)
 					if (iconName) {
-						if (group.folderIconName) {
-							determined = iconName === group.folderIconName
+						if (group.iconName) {
+							determined = iconName === group.iconName
 						} else {
 							determined = true
 						}

--- a/src/custom-sort/sorting-spec-processor.spec.ts
+++ b/src/custom-sort/sorting-spec-processor.spec.ts
@@ -1,7 +1,9 @@
 import {
 	CompoundDashNumberNormalizerFn,
 	CompoundDashRomanNumberNormalizerFn,
-	CompoundDotNumberNormalizerFn, ConsumedFolderMatchingRegexp, consumeFolderByRegexpExpression,
+	CompoundDotNumberNormalizerFn,
+	ConsumedFolderMatchingRegexp,
+	consumeFolderByRegexpExpression,
 	convertPlainStringToRegex,
 	detectNumericSortingSymbols,
 	escapeRegexUnsafeCharacters,
@@ -29,6 +31,8 @@ target-folder: tricky folder
  < a-z by-metadata: Some-dedicated-field
 with-metadata: Pages 
  > a-z by-metadata: 
+/: with-icon:
+with-icon: RiClock24
 starred:
 /:files starred:
 /folders starred:
@@ -85,6 +89,8 @@ target-folder: tricky folder 2
  < a-z by-metadata: Some-dedicated-field
 % with-metadata: Pages 
  > a-z by-metadata:
+/:files with-icon:
+/folders:files with-icon: RiClock24 
 /folders:files starred:
 /:files starred:
 /folders starred:
@@ -172,6 +178,14 @@ const expectedSortSpecsExampleA: { [key: string]: CustomSortSpec } = {
 			withMetadataFieldName: 'Pages',
 			order: CustomSortOrder.byMetadataFieldAlphabeticalReverse
 		}, {
+			type: CustomSortGroupType.HasIcon,
+			order: CustomSortOrder.alphabetical,
+			filesOnly: true
+		}, {
+			type: CustomSortGroupType.HasIcon,
+			order: CustomSortOrder.alphabetical,
+			iconName: 'RiClock24'
+		}, {
 			type: CustomSortGroupType.StarredOnly,
 			order: CustomSortOrder.alphabetical
 		}, {
@@ -186,7 +200,7 @@ const expectedSortSpecsExampleA: { [key: string]: CustomSortSpec } = {
 			order: CustomSortOrder.alphabetical,
 			type: CustomSortGroupType.Outsiders
 		}],
-		outsidersGroupIdx: 5,
+		outsidersGroupIdx: 7,
 		targetFoldersPaths: [
 			'tricky folder 2'
 		]

--- a/src/custom-sort/sorting-spec-processor.ts
+++ b/src/custom-sort/sorting-spec-processor.ts
@@ -207,6 +207,8 @@ const MetadataFieldIndicatorLexeme: string = 'with-metadata:'
 
 const StarredItemsIndicatorLexeme: string = 'starred:'
 
+const IconIndicatorLexeme: string = 'with-icon:'
+
 const CommentPrefix: string = '//'
 
 const PriorityModifierPrio1Lexeme: string = '/!'
@@ -1485,6 +1487,15 @@ export class SortingSpecProcessor {
 					return {
 						type: CustomSortGroupType.HasMetadataField,
 						withMetadataFieldName: metadataFieldName,
+						filesOnly: spec.filesOnly,
+						foldersOnly: spec.foldersOnly,
+						matchFilenameWithExt: spec.matchFilenameWithExt
+					}
+				} else if (theOnly.startsWith(IconIndicatorLexeme)) {
+					const iconName: string | undefined = extractIdentifier(theOnly.substring(IconIndicatorLexeme.length))
+					return {
+						type: CustomSortGroupType.HasIcon,
+						iconName: iconName,
 						filesOnly: spec.filesOnly,
 						foldersOnly: spec.foldersOnly,
 						matchFilenameWithExt: spec.matchFilenameWithExt

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -12,7 +12,24 @@ declare module 'obsidian' {
 		id: string;
 	}
 
+	export type CommunityPluginId = string
+
+	// undocumented internal interface - for experimental features
+	export interface CommunityPlugin {
+		manifest: {
+			id: CommunityPluginId
+		}
+		_loaded: boolean
+	}
+
+	// undocumented internal interface - for experimental features
+	export interface CommunityPlugins {
+		enabledPlugins: Set<CommunityPluginId>
+		plugins: {[key: CommunityPluginId]: CommunityPlugin}
+	}
+
 	export interface App {
+		plugins: CommunityPlugins;
 		internalPlugins: InternalPlugins; // undocumented internal API - for experimental features
 		viewRegistry: ViewRegistry;
 	}

--- a/src/utils/ObsidianIconFolderPluginSignature.ts
+++ b/src/utils/ObsidianIconFolderPluginSignature.ts
@@ -1,0 +1,48 @@
+import {App, CommunityPlugin, TAbstractFile, TFile, TFolder} from "obsidian";
+import {Starred_PluginInstance} from "./StarredPluginSignature";
+
+// For https://github.com/FlorianWoelki/obsidian-icon-folder
+
+export const ObsidianIconFolderPlugin_getData_methodName = 'getData'
+
+export interface FolderIconObject {
+    iconName: string | null;
+    inheritanceIcon: string;
+}
+
+export type ObsidianIconFolderPlugin_Data = Record<string, boolean | string | FolderIconObject | any>
+
+export interface ObsidianIconFolder_PluginInstance extends CommunityPlugin {
+    [ObsidianIconFolderPlugin_getData_methodName]: () => ObsidianIconFolderPlugin_Data
+}
+
+// https://github.com/FlorianWoelki/obsidian-icon-folder/blob/fd9c7df1486744450cec3d7ee9cee2b34d008e56/manifest.json#L2
+export const ObsidianIconFolderPluginId: string = 'obsidian-icon-folder'
+
+export const getIconFolderPlugin = (app?: App): ObsidianIconFolder_PluginInstance | undefined => {
+    const iconFolderPlugin: CommunityPlugin | undefined = app?.plugins?.plugins?.[ObsidianIconFolderPluginId]
+    if (iconFolderPlugin && iconFolderPlugin._loaded && app?.plugins?.enabledPlugins?.has(ObsidianIconFolderPluginId)) {
+        const iconFolderPluginInstance: ObsidianIconFolder_PluginInstance = iconFolderPlugin as ObsidianIconFolder_PluginInstance
+        // defensive programming, in case the community plugin changes its internal APIs
+        if (typeof iconFolderPluginInstance?.[ObsidianIconFolderPlugin_getData_methodName] === 'function') {
+            return iconFolderPluginInstance
+        }
+    }
+}
+
+// Intentionally partial and simplified, only detect icons configured directly,
+//    ignoring any icon inheritance or regexp-based applied icons
+export const determineIconOf = (entry: TAbstractFile, iconFolderPluginInstance: ObsidianIconFolder_PluginInstance): string | undefined => {
+    const iconsData: ObsidianIconFolderPlugin_Data | undefined = iconFolderPluginInstance[ObsidianIconFolderPlugin_getData_methodName]()
+    const entryForPath: any = iconsData?.[entry.path]
+    // Icons configured directly
+    if (typeof entryForPath === 'string') {
+        return entryForPath
+    } else if (typeof (entryForPath as FolderIconObject)?.iconName === 'string') {
+        return (entryForPath as FolderIconObject)?.iconName ?? undefined
+    } else {
+        return undefined
+    }
+}
+
+

--- a/src/utils/StarredPluginSignature.ts
+++ b/src/utils/StarredPluginSignature.ts
@@ -1,4 +1,4 @@
-import {PluginInstance, TFile} from "obsidian";
+import {App, InstalledPlugin, PluginInstance, TAbstractFile, TFile, TFolder} from "obsidian";
 
 export const StarredPlugin_findStarredFile_methodName = 'findStarredFile'
 
@@ -8,4 +8,36 @@ export interface findStarredFile_pathParam {
 
 export interface Starred_PluginInstance extends PluginInstance {
     [StarredPlugin_findStarredFile_methodName]: (filePath: findStarredFile_pathParam) => TFile | null
+}
+
+export const StarredCorePluginId: string = 'starred'
+
+export const getStarredPlugin = (app?: App): Starred_PluginInstance | undefined => {
+    const starredPlugin: InstalledPlugin | undefined = app?.internalPlugins?.getPluginById(StarredCorePluginId)
+    if (starredPlugin && starredPlugin.enabled && starredPlugin.instance) {
+        const starredPluginInstance: Starred_PluginInstance = starredPlugin.instance as Starred_PluginInstance
+        // defensive programming, in case Obsidian changes its internal APIs
+        if (typeof starredPluginInstance?.[StarredPlugin_findStarredFile_methodName] === 'function') {
+            return starredPluginInstance
+        }
+    }
+}
+
+const isFolder = (entry: TAbstractFile) => {
+    // The plain obvious 'entry instanceof TFolder' doesn't work inside Jest unit tests, hence a workaround below
+    return !!((entry as any).isRoot);
+}
+
+export const determineStarredStatusOfFolder = (folder: TFolder, starredPluginInstance: Starred_PluginInstance): boolean => {
+    return folder.children.some((folderItem) => {
+        return !isFolder(folderItem) && starredPluginInstance[StarredPlugin_findStarredFile_methodName]({path: folderItem.path})
+    })
+}
+
+export const determineStarredStatusOf = (entry: TFile | TFolder, aFile: boolean, starredPluginInstance: Starred_PluginInstance) => {
+    if (aFile) {
+        return !!starredPluginInstance[StarredPlugin_findStarredFile_methodName]({path: entry.path})
+    } else { // aFolder
+        return determineStarredStatusOfFolder(entry as TFolder, starredPluginInstance)
+    }
 }


### PR DESCRIPTION
- support for new lexeme `with-icon:` in group definition, with and w/o parameters
- integration with `obsidian-folder-icon` plugin:
  - icons set directly on files or folders are taken into account
  - icon inheritance and icons applied by regexp are ignored