### PR TITLE
#195 - support for metadata value matchers

### DIFF
--- a/src/custom-sort/custom-sort-types.ts
+++ b/src/custom-sort/custom-sort-types.ts
@@ -1,4 +1,5 @@
 import {MDataExtractor} from "./mdata-extractors";
+import {MDataMatcher} from "./mdata-matchers";
 
 export enum CustomSortGroupType {
 	Outsiders, // Not belonging to any of other groups
@@ -81,6 +82,7 @@ export interface CustomSortGroup {
 	matchFilenameWithExt?: boolean
 	foldersOnly?: boolean
 	withMetadataFieldName?: string // for 'with-metadata:' grouping
+	withMetadataMatcher?: MDataMatcher // optionally can come for 'with-metadata:' grouping
 	iconName?: string // for integration with obsidian-folder-icon community plugin
 	priority?: number
 	combineWithIdx?: number

--- a/src/custom-sort/custom-sort.ts
+++ b/src/custom-sort/custom-sort.ts
@@ -476,17 +476,24 @@ export const determineSortingGroup = function (entry: TFile | TFolder, spec: Cus
 						const notePathToScan: string = aFile ? entry.path : `${entry.path}/${entry.name}.md`
 						let frontMatterCache: FrontMatterCache | undefined = ctx._mCache.getCache(notePathToScan)?.frontmatter
 						let hasMetadata: boolean | undefined = frontMatterCache?.hasOwnProperty(group.withMetadataFieldName)
+						let metadataValue: string | undefined = hasMetadata ? frontMatterCache?.[group.withMetadataFieldName] : undefined
 						// For folders, if index-based folder note mode, scan the index file, giving it the priority
 						if (aFolder) {
 							const indexNoteBasename = ctx?.plugin?.indexNoteBasename()
 							if (indexNoteBasename) {
 								frontMatterCache = ctx._mCache.getCache(`${entry.path}/${indexNoteBasename}.md`)?.frontmatter
 								hasMetadata = hasMetadata || frontMatterCache?.hasOwnProperty(group.withMetadataFieldName)
+								metadataValue = hasMetadata ? frontMatterCache?.[group.withMetadataFieldName] : undefined
 							}
 						}
 
 						if (hasMetadata) {
-							determined = true
+							if (group.withMetadataMatcher) {
+									// note: empty metadata value doesn't match anything, by design
+								determined = !!(metadataValue && group.withMetadataMatcher(metadataValue))
+							} else {
+								determined = true
+							}
 						}
 					}
 				}

--- a/src/custom-sort/mdata-extractors.ts
+++ b/src/custom-sort/mdata-extractors.ts
@@ -7,7 +7,7 @@ type ExtractorFn = (mdataValue: string) => string|undefined
 
 interface DateExtractorSpec {
     specPattern: string|RegExp,
-    extractorFn: ExtractorFn
+    extractorFn: MDataExtractor
 }
 
 export interface MDataExtractor {

--- a/src/custom-sort/mdata-matchers.ts
+++ b/src/custom-sort/mdata-matchers.ts
@@ -1,0 +1,113 @@
+import {
+    getNormalizedDate_NormalizerFn_for
+} from "./matchers";
+import {NormalizerFn} from "./custom-sort-types";
+
+export interface MDataMatcher {
+    (mdataValue: string): boolean
+}
+
+export interface MDataMatcherFactory {
+    (specsMatch: string|RegExpMatchArray): MDataMatcher
+}
+
+interface ValueMatcherSpec {
+    specPattern: string|RegExp,
+    valueMatcherFnFactory: MDataMatcherFactory
+    unitTestsId: string
+}
+
+export interface MDataMatcherParseResult {
+    m: MDataMatcher
+    remainder: string
+}
+
+const VALUE_MATCHER_REGEX = /value\(([^)]+)\)/
+function getPlainValueMatcherFn(specsMatch: RegExpMatchArray) {
+    const EXACT_VALUE_IDX = 1 // Related to the spec regexp
+    const expectedValue = specsMatch[EXACT_VALUE_IDX].trim()
+    return (mdataValue: string): boolean => {
+        return mdataValue === expectedValue
+    }
+}
+
+const RANGE_MATCHER_REGEX = /range([[(])([^,]*),([^)\]]*)([)\]])/
+/*
+ range(aaa,bbb)
+ range[aaa,bbb)
+ range(, x)
+ range( y, ]
+ */
+enum RangeEdgeType { INCLUSIVE, EXCLUSIVE}
+function getRangeMatcherFn(specsMatch: RegExpMatchArray) {
+    const RANGE_START_TYPE_IDX = 1
+    const RANGE_START_IDX = 2
+    const RANGE_END_IDX = 3
+    const RANGE_END_TYPE_IDX = 4
+    const rangeStartType: RangeEdgeType = specsMatch[RANGE_END_TYPE_IDX] === '(' ? RangeEdgeType.EXCLUSIVE : RangeEdgeType.INCLUSIVE
+    const rangeStartValue: string = specsMatch[RANGE_START_IDX].trim()
+    const rangeEndValue: string = specsMatch[RANGE_END_IDX].trim()
+    const rangeEndType: RangeEdgeType = specsMatch[RANGE_END_TYPE_IDX] === ')' ? RangeEdgeType.EXCLUSIVE : RangeEdgeType.INCLUSIVE
+    return (mdataValue: string): boolean => {
+        let rangeStartMatched = true
+        if (rangeStartValue) {
+            if (rangeStartType === RangeEdgeType.INCLUSIVE) {
+                rangeStartMatched = mdataValue >= rangeStartValue
+            } else {
+                rangeStartMatched = mdataValue > rangeStartValue
+            }
+        }
+        let rangeEndMatched = true
+        if (rangeEndValue) {
+            if (rangeEndType === RangeEdgeType.INCLUSIVE) {
+                rangeEndMatched = mdataValue <= rangeEndValue
+            } else {
+                rangeEndMatched = mdataValue < rangeEndValue
+            }
+        }
+
+        return  rangeStartMatched && rangeEndMatched
+    }
+}
+
+const ValueMatchers: ValueMatcherSpec[] = [
+    {   specPattern: VALUE_MATCHER_REGEX,
+        valueMatcherFnFactory: getPlainValueMatcherFn,
+        unitTestsId: 'value'
+    }, {
+        specPattern: RANGE_MATCHER_REGEX,
+        valueMatcherFnFactory: getRangeMatcherFn,
+        unitTestsId: 'range'
+    }, {
+        specPattern: 'any-value',  // Artificially added for testing purposes
+        valueMatcherFnFactory: () => (s: string) => true,
+        unitTestsId: 'any-value-explicit'
+    }
+]
+
+export const tryParseAsMDataMatcherSpec = (s: string): MDataMatcherParseResult|undefined => {
+    // Simplistic initial implementation of the idea, not closing the way to more complex implementations
+    for (const matcherSpec of ValueMatchers) {
+        if ('string' === typeof matcherSpec.specPattern && s.trim().startsWith(matcherSpec.specPattern)) {
+            return {
+                m: matcherSpec.valueMatcherFnFactory(matcherSpec.specPattern),
+                remainder: s.substring(matcherSpec.specPattern.length).trim()
+            }
+        } else { // regexp
+            const match = s.match(matcherSpec.specPattern)
+            if (match) {
+                return {
+                    m: matcherSpec.valueMatcherFnFactory(match),
+                    remainder: s.substring(match[0].length).trim()
+                }
+            }
+        }
+    }
+    return undefined
+}
+
+export const _unitTests = {
+    matcherFn_value: ValueMatchers.find((it) => it.unitTestsId === 'value'),
+    matcherFn_range: ValueMatchers.find((it) => it.unitTestsId === 'range'),
+    matcherFn_anyValue: ValueMatchers.find((it) => it.unitTestsId === 'any-value-explicit'),
+}


### PR DESCRIPTION
- implementation completed, tested locally on a dedicated vault
- need to create unit tests for the new and modified areas before release

Sample syntax from test vault:

```yaml
---
sorting-spec: |
  with-metadata: biblio status matching: value(unread)
  with-metadata: biblio status matching: value(reading)
  with-metadata: biblio status matching: value(complete)
  def
---
```

```yaml
---
sorting-spec: |
  separator top
  with-metadata: n n matching: range(,123)
  separator 123
  with-metadata: n n matching: range[123,456]
  separator 456
  with-metadata: n n matching: range(456,)
  separator end
---
```

