### PR TITLE
215 template support in index note name

### DIFF
--- a/src/custom-sort/custom-sort.ts
+++ b/src/custom-sort/custom-sort.ts
@@ -21,7 +21,7 @@ import {
 	RegExpSpec
 } from "./custom-sort-types";
 import {
-	isDefined
+	isDefined, resolveIndexFileName
 } from "../utils/utils";
 import {
 	expandMacros
@@ -480,7 +480,8 @@ export const determineSortingGroup = function (entry: TFile | TFolder, spec: Cus
 						if (aFolder) {
 							const indexNoteBasename = ctx?.plugin?.indexNoteBasename()
 							if (indexNoteBasename) {
-								frontMatterCache = ctx._mCache.getCache(`${entry.path}/${indexNoteBasename}.md`)?.frontmatter
+								let resolvedIndexNoteBasename = resolveIndexFileName(indexNoteBasename, entry.parent?.name||'')
+								frontMatterCache = ctx._mCache.getCache(`${entry.path}/${resolvedIndexNoteBasename}.md`)?.frontmatter
 								hasMetadata = hasMetadata || frontMatterCache?.hasOwnProperty(group.withMetadataFieldName)
 							}
 						}
@@ -567,7 +568,8 @@ export const determineSortingGroup = function (entry: TFile | TFolder, spec: Cus
 				if (aFolder) {
 					const indexNoteBasename = ctx?.plugin?.indexNoteBasename()
 					if (indexNoteBasename) {
-						prioFrontMatterCache = ctx._mCache.getCache(`${entry.path}/${indexNoteBasename}.md`)?.frontmatter
+						let resolvedIndexNoteBasename = resolveIndexFileName(indexNoteBasename, entry.parent?.name||'')
+						prioFrontMatterCache = ctx._mCache.getCache(`${entry.path}/${resolvedIndexNoteBasename}.md`)?.frontmatter
 					}
 				}
 				if (isPrimaryOrderByMetadata) metadataValueToSortBy =

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ import {
 } from "./utils/ObsidianIconFolderPluginSignature";
 import {
 	extractBasename,
-	lastPathComponent,
+	lastPathComponent, resolveIndexFileName,
 	ValueOrError,
 } from "./utils/utils";
 import {
@@ -133,6 +133,11 @@ export default class CustomSortPlugin
 			if (file instanceof TFile) {
 				const aFile: TFile = file as TFile
 				const parent: TFolder = aFile.parent!
+				let resolvedIndexNoteNameForFolderNotes = ''
+				if (this.settings.indexNoteNameForFolderNotes) {
+					resolvedIndexNoteNameForFolderNotes = resolveIndexFileName(this.settings.indexNoteNameForFolderNotes, parent.name)
+				}
+
 				// Read sorting spec from three sources of equal priority:
 				// - files with designated predefined name
 				// - files with the same name as parent folders (aka folder notes), e.g.: References/References.md
@@ -148,8 +153,10 @@ export default class CustomSortPlugin
 					aFile.path === this.settings.additionalSortspecFile ||       // when user configured Inbox/sort.md
 					aFile.path === `${this.settings.additionalSortspecFile}.md` || // when user configured Inbox/sort
 
-					aFile.basename === this.settings.indexNoteNameForFolderNotes ||   // when user configured as index
-					aFile.name === this.settings.indexNoteNameForFolderNotes          // when user configured as index.md
+					(resolvedIndexNoteNameForFolderNotes && (
+					aFile.basename === resolvedIndexNoteNameForFolderNotes ||   // when user configured as index
+					aFile.name === resolvedIndexNoteNameForFolderNotes          // when user configured as index.md
+					))
 				) {
 					const sortingSpecTxt: string|undefined = mCache.getCache(aFile.path)?.frontmatter?.[SORTINGSPEC_YAML_KEY]
 					// Warning: newer Obsidian versions can return objects as well, hence the explicit check for string value

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,6 +111,8 @@ export class CustomSortSettingTab extends PluginSettingTab {
             + '>Aidenlx Folder Note preferences</a>'
             + ') enter here the index note name, e.g. <b>_about_</b> or <b>index</b>'
             + '<br>'
+            + ' The template {{parent-folder-name}} is supported, e.g. <b>_{{parent-folder-name}}</b>'
+            + '<br>'
             + ' The `.md` filename suffix is optional.'
             + '<br>'
             + 'This will tell the plugin to read sorting specs and also folders metadata from these files.'
@@ -125,7 +127,7 @@ export class CustomSortSettingTab extends PluginSettingTab {
             .setName('Name of index note (Folder Notes support)')
             .setDesc(indexNoteNameDescr)
             .addText(text => text
-                .setPlaceholder('e.g. _about_ or index')
+                .setPlaceholder('e.g. _about_ or index or _{{parent-folder-name}}')
                 .setValue(this.plugin.settings.indexNoteNameForFolderNotes)
                 .onChange(async (value) => {
                     this.plugin.settings.indexNoteNameForFolderNotes = value.trim() ? normalizePath(value) : '';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -25,6 +25,14 @@ export function extractBasename (configEntry: string | undefined): string | unde
 	}
 }
 
+export function resolveIndexFileName(indexFileName: string, parentFolderName: string): string {
+	if (parentFolderName && parentFolderName !== '/') {
+		return indexFileName.replace('{{parent-folder-name}}', parentFolderName)
+	} else {
+		return indexFileName
+	}
+}
+
 export class ValueOrError<V,E> {
 	constructor(private value?: V, private error?: E) {
 		if (value) this.error = undefined


### PR DESCRIPTION
#215 - Prototyping the support for {{parent-folder-name}} in settings of index note name.
- need to review with a fresh head
- unit tests - are the affected areas covered already?
- testing live needed, especially from the perspective of root folder handling