### PR TITLE
Handle deferred File Explorer view with a more elegant code

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -683,6 +683,8 @@ export default class CustomSortPlugin
 	}
 
 	onunload() {
+		// Trigger "plugin-unload" event
+		this.app.workspace.trigger('custom-sort:plugin-unload');
 	}
 
 	onUserEnable() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,14 +284,6 @@ export default class CustomSortPlugin
 						const sortingData = plugin.determineAndPrepareSortingDataForFolder(folder)
 
 						if (sortingData.sortSpec) {
-							if (!plugin.customSortAppliedAtLeastOnce) {
-								plugin.customSortAppliedAtLeastOnce = true
-								setTimeout(() => {
-									plugin.setRibbonIconToEnabled.apply(plugin)
-									plugin.showNotice('Custom sort APPLIED.');
-									plugin.updateStatusBar()
-								})
-							}
 							return getSortedFolderItems.call(this, folder, sortingData.sortSpec, plugin.createProcessingContextForSorting(sortingData.sortingAndGroupingStats))
 						} else {
 							return old.call(this, ...args);
@@ -346,6 +338,8 @@ export default class CustomSortPlugin
 					this.customSortAppliedAtLeastOnce = false
 					fileExplorer.view.requestSort();
 				}
+				this.setRibbonIconToEnabled()
+				this.showNotice('Custom sort APPLIED.')
 			} else {
 				setIcon(this.ribbonIconEl, ICON_SORT_SUSPENDED_SYNTAX_ERROR)
 				this.settings.suspended = true
@@ -713,7 +707,7 @@ export default class CustomSortPlugin
 
 	updateStatusBar() {
 		if (this.statusBarItemEl) {
-			let status = (!this.settings.suspended && this.customSortAppliedAtLeastOnce) ? 'ON' : 'OFF'
+			let status = !this.settings.suspended ? 'ON' : 'OFF'
 			this.statusBarItemEl.setText(`Custom sort:${status}`)
 		}
 	}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -62,4 +62,9 @@ declare module 'obsidian' {
 	interface MenuItem {
 		setSubmenu: () => Menu;
 	}
+
+	interface Workspace {
+		// Augmented event, triggered after unloading the plugin
+		on(name: 'custom-sort:plugin-unload', callback: () => unknown, ctx?: any): EventRef;
+	}
 }

--- a/src/utils/UndeferHandler.ts
+++ b/src/utils/UndeferHandler.ts
@@ -1,0 +1,53 @@
+import { App, Component, Plugin, View, WorkspaceLeaf } from 'obsidian';
+
+export class UndeferHandler extends Component {
+    app: App;
+    leaf: WorkspaceLeaf;
+    view: View;
+    callback?: (leaf: WorkspaceLeaf) => unknown;
+
+    constructor(leaf: WorkspaceLeaf, callback: (leaf: WorkspaceLeaf) => unknown) {
+        super();
+        this.app = leaf.app;
+        this.leaf = leaf;
+        this.view = leaf.view;
+        this.callback = callback;
+
+        this.view.addChild(this);
+    }
+
+    onload(): void {
+        // Run the callback immediately if the leaf is not deferred
+        if (!this.leaf.isDeferred) {
+            this.view.removeChild(this);
+            return;
+        }
+
+        // Detach the handler once the plugin has been disabled/unistalled
+        this.registerEvent(this.app.workspace.on(`custom-sort:plugin-unload`, () => this.detach()));
+    }
+
+    onunload(): void {
+        if (this.callback) this.runCallback();
+    }
+
+    // Detach the handler without invoking the callback
+    detach(): void {
+        delete this.callback;
+        this.view.removeChild(this);
+    }
+
+    private async runCallback(): Promise<void> {
+        // Run the callback after the actual view has been loaded
+        await sleep(0);
+        // Do not run the callback if the deferred view was unloaded
+        // because of being closed
+        if (
+            !this.leaf.isDeferred &&
+            this.leaf.parent &&
+            this.leaf.view.getViewType() !== 'empty'
+        ) {
+            this.callback?.(this.leaf);
+        }
+    }
+}

--- a/src/utils/UndeferHandler.ts
+++ b/src/utils/UndeferHandler.ts
@@ -1,4 +1,4 @@
-import { App, Component, Plugin, View, WorkspaceLeaf } from 'obsidian';
+import { App, Component, View, WorkspaceLeaf } from 'obsidian';
 
 export class UndeferHandler extends Component {
     app: App;
@@ -8,7 +8,7 @@ export class UndeferHandler extends Component {
 
     constructor(leaf: WorkspaceLeaf, callback: (leaf: WorkspaceLeaf) => unknown) {
         super();
-        this.app = leaf.app;
+        this.app = leaf.view.app;
         this.leaf = leaf;
         this.view = leaf.view;
         this.callback = callback;
@@ -24,7 +24,7 @@ export class UndeferHandler extends Component {
         }
 
         // Detach the handler once the plugin has been disabled/unistalled
-        this.registerEvent(this.app.workspace.on(`custom-sort:plugin-unload`, () => this.detach()));
+        this.registerEvent(this.app.workspace.on('custom-sort:plugin-unload', () => this.detach()));
     }
 
     onunload(): void {

--- a/src/utils/UndeferHandler.ts
+++ b/src/utils/UndeferHandler.ts
@@ -5,13 +5,16 @@ export class UndeferHandler extends Component {
     leaf: WorkspaceLeaf;
     view: View;
     callback?: (leaf: WorkspaceLeaf) => unknown;
+    // Called when the deferred leaf is detached before being fully loaded
+    onLeafDetach?: () => unknown;
 
-    constructor(leaf: WorkspaceLeaf, callback: (leaf: WorkspaceLeaf) => unknown) {
+    constructor(leaf: WorkspaceLeaf, callback: (leaf: WorkspaceLeaf) => unknown, onLeafDetach?: () => unknown) {
         super();
         this.app = leaf.view.app;
         this.leaf = leaf;
         this.view = leaf.view;
         this.callback = callback;
+        this.onLeafDetach = onLeafDetach;
 
         this.view.addChild(this);
     }
@@ -48,6 +51,8 @@ export class UndeferHandler extends Component {
             this.leaf.view.getViewType() !== 'empty'
         ) {
             this.callback?.(this.leaf);
+        } else {
+            this.onLeafDetach?.();
         }
     }
 }


### PR DESCRIPTION
If we look closely at `View` instance, we will find that [`View`][view-api], including `DeferredView`, is one of [`Component`][component-api] subclasses ([`Plugin`][plugin-api] is also one of them). Therefore, we can register a callback that will be called once the `DeferredView` has been unloaded, being exchanged with the actual view.

Progress:
- [x] Add a handler that handles invoking callback on undeferred view.
- [x] Apply the logic to the File Explorer view.
- [x] Test the plugin

This PR also introduces some changes:
- Be able to switch custom sort on and off even the core plugin `Files` is disabled.
- No thrown error caused by the absence of File Explorer view.
- `setWatcherForDelayedFileExplorerView()` and `delayedApplicationOfCustomSorting()` are no longer in use.

[view-api]: https://docs.obsidian.md/Reference/TypeScript+API/View
[component-api]: https://docs.obsidian.md/Reference/TypeScript+API/Component
[plugin-api]: https://docs.obsidian.md/Reference/TypeScript+API/Plugin