### PR TITLE
Add vsc-unicode-natural sort order (VS Code / Windows Explorer style)

### DIFF
--- a/src/custom-sort/custom-sort-types.ts
+++ b/src/custom-sort/custom-sort-types.ts
@@ -46,6 +46,8 @@ export enum CustomSortOrder {
 	alphabeticalWithFoldersPreferred, // When the (base)names are equal, the file has precedence over a folder,
 	vscUnicode, // the Visual Studio Code lexicographic order named 'unicode' (which is very misleading, at the same time familiar to VS Code users
 	vscUnicodeReverse,         // ... see compareFilesUnicode function https://github.com/microsoft/vscode/blob/a19b2d5fb0202e00fb930dc850d2695ec512e495/src/vs/base/common/comparers.ts#L80
+	vscUnicodeNatural, // vsc-unicode but digit runs compared numerically (Part 2 < Part 10), non-digits by UTF-16 codepoint (ASCII < CJK)
+	vscUnicodeNaturalReverse,
 	default = alphabeticalWithFilesPreferred
 }
 

--- a/src/custom-sort/custom-sort.ts
+++ b/src/custom-sort/custom-sort.ts
@@ -52,6 +52,17 @@ export const CollatorTrueAlphabeticalCompare = new Intl.Collator(undefined, {
 	numeric: false,
 }).compare;
 
+// VS Code / Windows Explorer style comparator: Intl.Collator with 'en' locale (UCA defaults)
+// - punctuation/symbols precede letters (so "[TODO]" < "CLAUDE")
+// - digit runs compared numerically (so "Part 2" < "Part 10")
+// - Latin precedes CJK (so "Part" < "부록")
+// - base sensitivity (case-insensitive, accent-insensitive)
+export const CollatorCompareVscNatural = new Intl.Collator('en', {
+	usage: "sort",
+	sensitivity: "base",
+	numeric: true,
+}).compare;
+
 export interface FolderItemForSorting {
 	path: string
 	groupIdx?: number  // the index itself represents order for groups
@@ -207,6 +218,8 @@ const Sorters: { [key in CustomSortOrder]: SorterFn } = {
 	[CustomSortOrder.folderFirst]: (a: FIFS, b: FIFS) => (a.isFolder === b.isFolder) ? EQUAL_OR_UNCOMPARABLE : (a.isFolder ? -1 : 1),
 	[CustomSortOrder.vscUnicode]: (a: FIFS, b: FIFS) => (a.sortString === b.sortString) ? EQUAL_OR_UNCOMPARABLE : (a.sortString < b.sortString ? -1 : 1),
 	[CustomSortOrder.vscUnicodeReverse]: (a: FIFS, b: FIFS) => (a.sortString === b.sortString) ? EQUAL_OR_UNCOMPARABLE : (b.sortString < a.sortString ? -1 : 1),
+	[CustomSortOrder.vscUnicodeNatural]: (a: FIFS, b: FIFS) => CollatorCompareVscNatural(a.sortStringWithExt, b.sortStringWithExt),
+	[CustomSortOrder.vscUnicodeNaturalReverse]: (a: FIFS, b: FIFS) => CollatorCompareVscNatural(b.sortStringWithExt, a.sortStringWithExt),
 
 	// A fallback entry which should not be used - the getSorterFor() function below should protect against it
 	[CustomSortOrder.standardObsidian]: (a: FIFS, b: FIFS) => CollatorCompare(a.sortString, b.sortString),

--- a/src/custom-sort/sorting-spec-processor.ts
+++ b/src/custom-sort/sorting-spec-processor.ts
@@ -146,6 +146,8 @@ const OrderLiterals: { [key: string]: CustomSortOrderAscDescPair } = {
     'by-bookmarks-order': {asc: CustomSortOrder.byBookmarkOrder, desc: CustomSortOrder.byBookmarkOrderReverse},
 	'files-first': {asc: CustomSortOrder.fileFirst, desc: CustomSortOrder.fileFirst},
 	'folders-first': {asc: CustomSortOrder.folderFirst, desc: CustomSortOrder.folderFirst},
+	'vsc-unicode-natural': {asc: CustomSortOrder.vscUnicodeNatural, desc: CustomSortOrder.vscUnicodeNaturalReverse},
+	'unicode-charcode-natural': {asc: CustomSortOrder.vscUnicodeNatural, desc: CustomSortOrder.vscUnicodeNaturalReverse},
 	'vsc-unicode': {asc: CustomSortOrder.vscUnicode, desc: CustomSortOrder.vscUnicodeReverse},
 	'unicode-charcode': {asc: CustomSortOrder.vscUnicode, desc: CustomSortOrder.vscUnicodeReverse}
 }

--- a/src/test/unit/sorting-spec-processor.spec.ts
+++ b/src/test/unit/sorting-spec-processor.spec.ts
@@ -914,6 +914,50 @@ describe('SortingSpecProcessor', () => {
 	})
 })
 
+const txtInputVscUnicodeNaturalSortAttr: string = `
+target-folder: VS Code unicode natural
+%
+  > unicode-charcode-natural
+< vsc-unicode-natural
+target-folder: VS Code unicode natural reverse
+%
+  < unicode-charcode-natural
+> vsc-unicode-natural
+`
+
+const expectedSortSpecForVscUnicodeNaturalSorting: { [key: string]: CustomSortSpec } = {
+	"VS Code unicode natural": {
+		defaultSorting: { order: CustomSortOrder.vscUnicodeNatural, },
+		groups: [{
+			type: CustomSortGroupType.Outsiders,
+			sorting: { order: CustomSortOrder.vscUnicodeNaturalReverse },
+		}],
+		outsidersGroupIdx: 0,
+		targetFoldersPaths: ['VS Code unicode natural']
+	},
+	"VS Code unicode natural reverse": {
+		defaultSorting: { order: CustomSortOrder.vscUnicodeNaturalReverse, },
+		groups: [{
+			type: CustomSortGroupType.Outsiders,
+			sorting: { order: CustomSortOrder.vscUnicodeNatural },
+		}],
+		outsidersGroupIdx: 0,
+		targetFoldersPaths: ['VS Code unicode natural reverse']
+	}
+}
+
+describe('SortingSpecProcessor', () => {
+	let processor: SortingSpecProcessor;
+	beforeEach(() => {
+		processor = new SortingSpecProcessor();
+	});
+	it('should recognize the vsc-unicode-natural sorting attribute for a folder', () => {
+		const inputTxtArr: Array<string> = txtInputVscUnicodeNaturalSortAttr.split('\n')
+		const result = processor.parseSortSpecFromText(inputTxtArr, 'mock-folder', 'custom-name-note.md')
+		expect(result?.sortSpecByPath).toEqual(expectedSortSpecForVscUnicodeNaturalSorting)
+	})
+})
+
 const txtInputSimplistic1: string = `
 target-folder: /*
 /:files


### PR DESCRIPTION
## Summary

Adds a new sort order token **`vsc-unicode-natural`** (alias: `unicode-charcode-natural`) that combines the existing `vsc-unicode` ordering with numeric-aware digit-run comparison. This mimics the default file sort behavior of **VS Code** and **Windows Explorer**.

## Motivation

Users whose system locale is non-Latin (e.g. `ko-KR`, `ja-JP`) currently face a gap between the two closest existing options:

| Option | Latin before CJK? | Natural number sort? |
|---|---|---|
| `< a-z` | ❌ CJK-first in many locales | ✅ |
| `< vsc-unicode` | ✅ | ❌ `Part 10 < Part 2` |
| **`< vsc-unicode-natural`** (new) | ✅ | ✅ |

Concrete example from a Korean-locale vault with a book folder containing `Part 0` through `Part 8`, `부록 A`, `부록 B`, `부록 C`:

- With `< a-z` → `부록 A`, `부록 B`, `부록 C`, `Part 0`, ... (CJK first)
- With `< vsc-unicode` → `Part 0`, ..., `Part 8`, `부록 A`, ... (ok for now) but `Part 10` would sort before `Part 2`
- With `< vsc-unicode-natural` → correct Windows/VSCode order, scales to `Part 10+`

## Implementation

Uses ` + '`Intl.Collator`' + `(`' + `'en'` + `, { numeric: true, sensitivity: 'base' })`:

- Fixed `en` locale so collation is consistent across user machines; CJK stays after Latin via UCA defaults
- `numeric: true` enables natural digit-run comparison
- `sensitivity: 'base'` matches the existing alphabetical comparator's case/accent-insensitivity
- Punctuation/symbols precede letters via UCA weights, so `[TODO]` correctly sorts before `CLAUDE` (matches VS Code behavior)
- Uses `sortStringWithExt` so files with identical basenames but different suffixes (e.g. ` + '`name (variant).md`' + ` vs ` + '`name.md`' + `) sort the way VS Code orders them

## Changes

- `CustomSortOrder` enum: add `vscUnicodeNatural` / `vscUnicodeNaturalReverse`
- `custom-sort.ts`: add `CollatorCompareVscNatural` and two `Sorters` entries
- `sorting-spec-processor.ts`: register `vsc-unicode-natural` and `unicode-charcode-natural` tokens. **Important:** these are placed **before** the existing `vsc-unicode` / `unicode-charcode` entries because the parser uses a `startsWith` match on `Object.keys(OrderLiterals)` in declaration order, otherwise `vsc-unicode-natural` is partially matched as `vsc-unicode` with `-natural` as trailing garbage
- `sorting-spec-processor.spec.ts`: add a parser recognition test that parallels the existing `vsc-unicode` coverage

## Tests

All 831 existing tests pass, plus the new test for `vsc-unicode-natural` / `unicode-charcode-natural` token recognition.

## Example usage

```yaml
---
sorting-spec: |-
  target-folder: /*
  /folders
    < vsc-unicode-natural
  /:files
    < vsc-unicode-natural
---
```

## Notes

- No changes to `manifest.json`, `package.json`, or `versions.json` since those are release-time concerns
- Backward compatible: existing sortspecs using `< vsc-unicode` or `< a-z` continue to work unchanged
- Happy to adjust token naming (e.g. `vsc-unicode-numeric`), add more tests, or split into smaller PRs if preferred