### PR TITLE
feat: automatic periodic bookmarks sync

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,6 +103,8 @@ export default class CustomSortPlugin
 
 	uninstallerOfFileExplorerPatch: MonkeyAroundUninstaller|undefined = undefined
 
+	bookmarksSyncTimerId: ReturnType<typeof setInterval> | undefined = undefined
+
 	showNotice(message: string, timeout?: number) {
 		if (this.settings.notificationsEnabled || (Platform.isMobile && this.settings.mobileNotificationsEnabled)) {
 			new Notice(message, timeout)
@@ -374,6 +376,8 @@ export default class CustomSortPlugin
 		this.registerPluginUnloadHandler()
 
 		this.initialize();
+
+		this.restartBookmarksSyncTimer();
 	}
 
 	registerEventHandlers() {
@@ -582,6 +586,16 @@ export default class CustomSortPlugin
 				bookmarksPlugin.saveDataAndUpdateBookmarkViews(true)
 			}
 		})
+
+		this.app.vault.on("create", (file: TAbstractFile) => {
+			if (plugin.settings.bookmarksSyncIntervalSeconds <= 0) return
+			const bookmarksPlugin = getBookmarksPlugin(plugin.app, plugin.settings.bookmarksGroupToConsumeAsOrderingReference)
+			if (bookmarksPlugin && file.parent) {
+				const orderedChildren: Array<TAbstractFile> = plugin.orderedFolderItemsForBookmarking(file.parent, bookmarksPlugin)
+				bookmarksPlugin.syncSiblings(orderedChildren)
+				bookmarksPlugin.saveDataAndUpdateBookmarkViews(true)
+			}
+		})
 	}
 
 	uninstallFileExplorerPatchIfInstalled() {
@@ -697,9 +711,9 @@ export default class CustomSortPlugin
 	}
 
 	syncBookmarksRecursive(folder: TFolder, bookmarksPlugin: BookmarksPluginInterface): void {
-		// Sync the current folder: bookmark all children that are not yet bookmarked (appended at end)
+		// Sync the current folder: reorder bookmarks to match file explorer order and remove orphans
 		const orderedChildren: Array<TAbstractFile> = this.orderedFolderItemsForBookmarking(folder, bookmarksPlugin)
-		bookmarksPlugin.bookmarkSiblings(orderedChildren)
+		bookmarksPlugin.syncSiblings(orderedChildren)
 
 		// Recurse into subfolders
 		for (const child of folder.children) {
@@ -709,7 +723,36 @@ export default class CustomSortPlugin
 		}
 	}
 
+	runBookmarksSyncForVault(): void {
+		if (this.settings.suspended) return
+		const bookmarksPlugin = getBookmarksPlugin(this.app, this.settings.bookmarksGroupToConsumeAsOrderingReference)
+		if (!bookmarksPlugin) return
+		const rootFolder: TFolder = this.app.vault.getRoot()
+		this.syncBookmarksRecursive(rootFolder, bookmarksPlugin)
+		bookmarksPlugin.saveDataAndUpdateBookmarkViews(true)
+	}
+
+	restartBookmarksSyncTimer(): void {
+		// Clear existing timer
+		if (this.bookmarksSyncTimerId !== undefined) {
+			clearInterval(this.bookmarksSyncTimerId)
+			this.bookmarksSyncTimerId = undefined
+		}
+
+		// Start new timer if interval > 0
+		const intervalSeconds = this.settings.bookmarksSyncIntervalSeconds
+		if (intervalSeconds > 0) {
+			this.bookmarksSyncTimerId = setInterval(() => {
+				this.runBookmarksSyncForVault()
+			}, intervalSeconds * 1000)
+		}
+	}
+
 	onunload() {
+		if (this.bookmarksSyncTimerId !== undefined) {
+			clearInterval(this.bookmarksSyncTimerId)
+			this.bookmarksSyncTimerId = undefined
+		}
 	}
 
 	onUserEnable() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -444,6 +444,19 @@ export default class CustomSortPlugin
 				});
 			};
 
+		const getSyncBookmarksRecursiveMenuItemForFile = (file: TAbstractFile): ContextMenuProvider =>
+			(item: MenuItem) => {
+				item.setTitle(m ? 'Sync bookmarks for custom sorting (recursive)' : 'Sync bookmarks for sorting (recursive)');
+				item.onClick(() => {
+					const bookmarksPlugin = getBookmarksPlugin(plugin.app, plugin.settings.bookmarksGroupToConsumeAsOrderingReference)
+					if (bookmarksPlugin) {
+						const targetFolder: TFolder = (file instanceof TFolder) ? file : file.parent!
+						plugin.syncBookmarksRecursive(targetFolder, bookmarksPlugin)
+						bookmarksPlugin.saveDataAndUpdateBookmarkViews(true)
+					}
+				});
+			};
+
 		const getBookmarkSelectedMenuItemForFiles = (files: TAbstractFile[]): ContextMenuProvider =>
 			(item: MenuItem) => {
 				item.setTitle(m ? 'Bookmark selected for custom sorting' : 'Custom sort: bookmark selected for sorting');
@@ -500,6 +513,7 @@ export default class CustomSortPlugin
 							}
 							(submenu ?? menu).addItem(getBookmarkAllMenuItemForFile(file));
 							(submenu ?? menu).addItem(getUnbookmarkAllMenuItemForFile(file));
+							(submenu ?? menu).addItem(getSyncBookmarksRecursiveMenuItemForFile(file));
 						}
 					}
 
@@ -680,6 +694,19 @@ export default class CustomSortPlugin
 			this.createProcessingContextForSorting(has),
 			uiSortOrder
 		)
+	}
+
+	syncBookmarksRecursive(folder: TFolder, bookmarksPlugin: BookmarksPluginInterface): void {
+		// Sync the current folder: bookmark all children that are not yet bookmarked (appended at end)
+		const orderedChildren: Array<TAbstractFile> = this.orderedFolderItemsForBookmarking(folder, bookmarksPlugin)
+		bookmarksPlugin.bookmarkSiblings(orderedChildren)
+
+		// Recurse into subfolders
+		for (const child of folder.children) {
+			if (child instanceof TFolder) {
+				this.syncBookmarksRecursive(child, bookmarksPlugin)
+			}
+		}
 	}
 
 	onunload() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,6 +254,7 @@ export default class CustomSortPlugin
 						if (sortingData.sortSpec) {
 							if (!plugin.customSortAppliedAtLeastOnce) {
 								plugin.customSortAppliedAtLeastOnce = true
+								plugin.restartBookmarksSyncTimer()
 								setTimeout(() => {
 									plugin.setRibbonIconToEnabled.apply(plugin)
 									plugin.showNotice('Custom sort APPLIED.');
@@ -376,8 +377,6 @@ export default class CustomSortPlugin
 		this.registerPluginUnloadHandler()
 
 		this.initialize();
-
-		this.restartBookmarksSyncTimer();
 	}
 
 	registerEventHandlers() {
@@ -589,6 +588,7 @@ export default class CustomSortPlugin
 
 		this.app.vault.on("create", (file: TAbstractFile) => {
 			if (plugin.settings.bookmarksSyncIntervalSeconds <= 0) return
+			if (!plugin.customSortAppliedAtLeastOnce) return
 			const bookmarksPlugin = getBookmarksPlugin(plugin.app, plugin.settings.bookmarksGroupToConsumeAsOrderingReference)
 			if (bookmarksPlugin && file.parent) {
 				const orderedChildren: Array<TAbstractFile> = plugin.orderedFolderItemsForBookmarking(file.parent, bookmarksPlugin)
@@ -725,6 +725,7 @@ export default class CustomSortPlugin
 
 	runBookmarksSyncForVault(): void {
 		if (this.settings.suspended) return
+		if (!this.customSortAppliedAtLeastOnce) return
 		const bookmarksPlugin = getBookmarksPlugin(this.app, this.settings.bookmarksGroupToConsumeAsOrderingReference)
 		if (!bookmarksPlugin) return
 		const rootFolder: TFolder = this.app.vault.getRoot()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface CustomSortPluginSettings {
     bookmarksContextMenus: boolean
     bookmarksGroupToConsumeAsOrderingReference: string
     delayForInitialApplication: number // miliseconds
+    bookmarksSyncIntervalSeconds: number // 0 = disabled
 }
 
 const MILIS = 1000
@@ -21,6 +22,10 @@ const DEFAULT_DELAY_SECONDS = 1
 const DELAY_MIN_SECONDS = 0
 const DELAY_MAX_SECONDS = 30
 const DEFAULT_DELAY = DEFAULT_DELAY_SECONDS * MILIS
+
+const SYNC_INTERVAL_MIN_SECONDS = 0
+const SYNC_INTERVAL_MAX_SECONDS = 3600
+const DEFAULT_SYNC_INTERVAL_SECONDS = 0
 
 export const DEFAULT_SETTINGS: CustomSortPluginSettings = {
     additionalSortspecFile: '',
@@ -33,7 +38,8 @@ export const DEFAULT_SETTINGS: CustomSortPluginSettings = {
     automaticBookmarksIntegration: false,
     bookmarksContextMenus: false,
     bookmarksGroupToConsumeAsOrderingReference: 'sortspec',
-    delayForInitialApplication: DEFAULT_DELAY
+    delayForInitialApplication: DEFAULT_DELAY,
+    bookmarksSyncIntervalSeconds: DEFAULT_SYNC_INTERVAL_SECONDS
 }
 
 // On API 1.2.x+ enable the bookmarks integration by default
@@ -245,6 +251,30 @@ export class CustomSortSettingTab extends PluginSettingTab {
                         this.plugin.settings.customSortContextSubmenu = true; // automatically enable custom sort context submenu
                     }
                     await this.plugin.saveSettings();
+                }))
+
+        const bookmarksSyncIntervalDescr: DocumentFragment = sanitizeHTMLToDom(
+            'Interval in seconds for automatic synchronization of bookmarks with the file explorer order.'
+            + '<br>'
+            + 'Set to <b>0</b> to disable automatic sync (manual sync via context menu is still available).'
+            + '<br>'
+            + 'When enabled, the plugin will periodically ensure that bookmarks reflect the current file/folder structure and sorting order.'
+            + '<br>'
+            + `Min: ${SYNC_INTERVAL_MIN_SECONDS} sec., max: ${SYNC_INTERVAL_MAX_SECONDS} sec.`
+        )
+
+        new Setting(containerEl)
+            .setName('Automatic bookmarks sync interval')
+            .setDesc(bookmarksSyncIntervalDescr)
+            .addText(text => text
+                .setPlaceholder('0')
+                .setValue(`${this.plugin.settings.bookmarksSyncIntervalSeconds}`)
+                .onChange(async (value) => {
+                    let interval = parseInt(value)
+                    interval = (Number.isNaN(interval) || !Number.isFinite(interval)) ? DEFAULT_SYNC_INTERVAL_SECONDS : (interval < SYNC_INTERVAL_MIN_SECONDS ? SYNC_INTERVAL_MIN_SECONDS : (interval > SYNC_INTERVAL_MAX_SECONDS ? SYNC_INTERVAL_MAX_SECONDS : interval))
+                    this.plugin.settings.bookmarksSyncIntervalSeconds = interval
+                    await this.plugin.saveSettings()
+                    this.plugin.restartBookmarksSyncTimer()
                 }))
     }
 }

--- a/src/utils/BookmarksCorePluginSignature.ts
+++ b/src/utils/BookmarksCorePluginSignature.ts
@@ -82,6 +82,7 @@ export interface BookmarksPluginInterface {
     saveDataAndUpdateBookmarkViews(updateBookmarkViews: boolean): void
     bookmarkSiblings(siblings: Array<TAbstractFile>, inTheTop?: boolean): void
     unbookmarkSiblings(siblings: Array<TAbstractFile>): void
+    syncSiblings(orderedSiblings: Array<TAbstractFile>): void
     updateSortingBookmarksAfterItemRenamed(renamedItem: TAbstractFile, oldPath: string): void
     updateSortingBookmarksAfterItemDeleted(deletedItem: TAbstractFile): void
     isBookmarkedForSorting(item: TAbstractFile): boolean
@@ -228,6 +229,58 @@ class BookmarksPluginWrapper implements BookmarksPluginInterface {
                 }
             });
         }
+    }
+
+    // Sync bookmarks to match the given ordered siblings exactly:
+    // - Reorder existing bookmark entries to match the order of orderedSiblings
+    // - Add missing items at their correct position
+    // - Remove orphaned entries (items in bookmarks that are not in orderedSiblings)
+    syncSiblings = (orderedSiblings: Array<TAbstractFile>) => {
+        if (orderedSiblings.length === 0) return
+
+        const bookmarksContainer: BookmarkedParentFolder|undefined = findGroupForItemPathInBookmarks(
+            orderedSiblings[0].path,
+            CreateIfMissing,
+            this.plugin!,
+            this.groupNameForSorting
+        )
+
+        if (!bookmarksContainer) return
+
+        const reordered: Array<BookmarkedItem> = []
+        const matchedItems: Set<BookmarkedItem> = new Set()
+
+        for (const aSibling of orderedSiblings) {
+            const siblingName = lastPathComponent(aSibling.path)
+
+            // Find existing bookmark entry for this sibling
+            const existing = bookmarksContainer.items.find((it) =>
+                ((it.type === 'folder' || it.type === 'file') && it.path === aSibling.path) ||
+                (it.type === 'group' && groupNameForPath(it.title||'') === siblingName)
+            )
+
+            if (existing) {
+                // If it was a group transparent for sorting, make it visible again
+                if (existing.type === 'group' && isGroupTransparentForSorting(existing.title)) {
+                    existing.title = groupNameForPath(existing.title||'')
+                }
+                reordered.push(existing)
+                matchedItems.add(existing)
+            } else {
+                // Create new entry at the correct position
+                const newEntry: BookmarkedItem = (aSibling instanceof TFolder)
+                    ? createBookmarkGroupEntry(siblingName)
+                    : createBookmarkFileEntry(aSibling.path)
+                reordered.push(newEntry)
+            }
+        }
+
+        // Remove orphaned entries: items in bookmarks that have no corresponding file/folder
+        // (they are simply not included in reordered)
+
+        // Replace the container items with the reordered list
+        bookmarksContainer.items.length = 0
+        bookmarksContainer.items.push(...reordered)
     }
 
     updateSortingBookmarksAfterItemRenamed = (renamedItem: TAbstractFile, oldPath: string): void => {


### PR DESCRIPTION
## Summary

This PR adds **automatic periodic synchronization** of sorting bookmarks with the file explorer, addressing the feature requests in #108 and #192.

### What it does

1. **Full bookmark sync** (`syncSiblings`): A new method that enforces the correct file explorer order in bookmarks. Unlike the existing `bookmarkSiblings` (which only appends missing items), this method:
   - Reorders existing bookmark entries to match the current sorting order
   - Inserts new items at their correct position (not just appended at the end)
   - Removes orphaned entries (bookmarks for files/folders that no longer exist)

2. **Configurable auto-sync timer**: A new setting `Automatic bookmarks sync interval` (in seconds). Set to `0` to disable (default). When enabled, the plugin periodically runs a full vault-wide bookmark sync.

3. **Immediate sync on file creation**: When auto-sync is enabled, newly created files/folders are immediately synced into the correct bookmark position via a `vault.on('create')` handler.

4. **Manual recursive sync** (context menu): A new context menu entry *Sync bookmarks for sorting (recursive)* that performs a one-shot full sync on a folder and all its descendants.

### How to use

1. Enable the Bookmarks integration in plugin settings (if not already enabled)
2. Set the **Automatic bookmarks sync interval** to your desired value (e.g. `60` for once per minute)
3. The plugin will now keep bookmarks in sync with your file/folder structure automatically

For manual one-shot sync: right-click any folder in File Explorer → Custom sort → *Sync bookmarks for sorting (recursive)*

### Addressing concerns from #108 and #192

Sebastian raised several valid concerns about automatic bookmark synchronization:

**"Keeping bookmarks in sync is technically not feasible"**
The periodic full-sync approach sidesteps the event-based synchronization problems. Rather than trying to catch every individual file system event in real-time, we periodically reconcile the entire state. Missed events (e.g. during plugin startup) are corrected at the next sync cycle. The `vault.on('create')` handler provides near-instant sync for the most common case (new files).

**"Duplicate bookmark entries when rearranging items"**
The `syncSiblings` method completely replaces the bookmark list for each folder with the correct ordered set. Any duplicates or orphans are eliminated on every sync cycle.

**"High implementation/maintenance effort due to Obsidian breaking changes"**
This implementation reuses the existing plugin infrastructure exclusively (`orderedFolderItemsForBookmarking`, `findGroupForItemPathInBookmarks`, the existing bookmark data structures). No new Obsidian API dependencies are introduced. The maintenance surface is minimal: one new method in `BookmarksPluginWrapper`, a timer, and a create-event handler.

**"Conflict with manual drag & drop ordering"**
This is an inherent trade-off: when auto-sync is enabled, manually reordered bookmarks will be overwritten at the next sync cycle. This is by design — the setting is opt-in (disabled by default) and intended for users who want bookmarks to mirror the sorting spec automatically. Users who prefer manual bookmark ordering should leave the interval at `0`.

### Technical details

- No performance concerns for typical vaults: the sync only writes to disk when triggered by the timer or create-event
- The timer is properly cleaned up on plugin unload
- Changing the interval in settings immediately restarts the timer (no reload required)
